### PR TITLE
DTSPO-5553 Switch to v2 storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,6 @@ resource "azurerm_storage_account" "storage_account" {
   location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  account_kind             = "BlobStorage"
   allow_blob_public_access = true
 
   tags = var.common_tags


### PR DESCRIPTION
Please see https://tools.hmcts.net/jira/browse/DTSPO-5553

This is step 1 of 2 in the Storage HA work in progress.
In order for Storage to use high availability we need to use a v2 account, currently this is using a v1 because of how it was setup.

This will be migrated in the background using an Azure migration process and then terraform ran afterwards to refresh the state